### PR TITLE
correction du double ! dans le Path

### DIFF
--- a/Applications/NemoNetwork/lib/class.nntp.php
+++ b/Applications/NemoNetwork/lib/class.nntp.php
@@ -290,7 +290,7 @@ class NNTP
 
 		mb_internal_encoding('UTF-8');
 
-		$article = "Path: !from-jntp\r\n";
+		$article = "Path: from-jntp\r\n";
 		$article .= "Message-ID: <".$json{'Data'}{'DataID'}.">\r\n";
 		$article .= "JNTP-Route: ".implode("|", $json{'Route'})."\r\n";
 		$OriginServer = $json{'Data'}{'OriginServer'};


### PR DESCRIPTION
Dans un Path, on ne commence pas par '!' qui est un séparateur
